### PR TITLE
update dependencies and implement on/off toggle

### DIFF
--- a/app.css
+++ b/app.css
@@ -13,3 +13,9 @@
   right: 15px;
   bottom: 15px;
 }
+
+.btn-sendnow {
+	position: absolute;
+	left: 15px;
+	bottom: 15px;
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="app.css">
   </head>
   <body>
+  	<div id="content"></div>
     <script type="text/javascript" src="./app.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,26 +1,30 @@
+const path = require('path')
+
 var menubar = require('menubar')
 
-var ipc = require('ipc')
-var run = require('./index.js')
+var ipcMain = require('electron').ipcMain
+var itunes = require('./index.js')
 
-var mb = menubar({ preloadWindow: true })
+var mb = menubar({ preloadWindow: true, icon: path.join(__dirname, '/Icon.png') })
 
 mb.on('ready', function ready () {
-  require('electron-template-menu')()
-
-  ipc.on('data', function (event, data) {
-    console.log(data)
+  ipcMain.on('data', function (event, data) {
     update(data)
   })
 
-  ipc.once('data', run)
+  ipcMain.once('data', itunes.listen)
 })
 
-ipc.on('terminate', function terminate () {
-  mb.app.terminate()
+ipcMain.on('terminate', function terminate () {
+  mb.app.quit()
+})
+
+ipcMain.on('sendnow', function sendnow () {
+  itunes.sendNow()
 })
 
 function update (state) {
   process.env.SLACK_WEBHOOK_URL = state.slackWebhookUrl
   process.env.LISTENER_NAME = state.listenerName
+  process.env.AUTO_SEND = state.autoSend
 }

--- a/package.json
+++ b/package.json
@@ -1,36 +1,39 @@
 {
   "name": "playing",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Send what you're playing on iTunes to Slack",
   "main": "main.js",
   "scripts": {
     "test": "standard",
-    "start": "node index.js",
-    "build": "electron-packager ./ playing --out build/ --platform=darwin --arch=x64 --version=0.30.6 --icon=./Icon.icns --overwrite --prune --app-version \"$(node -pe \"require('./package.json').version\")\""
+    "start": "electron ./",
+    "build": "electron-packager ./ playing --out build/ --platform=darwin --arch=x64 --version=1.2.6 --icon=./Icon.icns --overwrite --prune --app-version \"$(node -pe \"require('./package.json').version\")\""
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/uiureo/playing.git"
   },
   "author": "Kazato Sugimoto",
+  "contributors": [{
+    "name": "Till Kothe"
+  }],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/uiureo/playing/issues"
   },
   "homepage": "https://github.com/uiureo/playing#readme",
   "dependencies": {
-    "electron-template-menu": "^1.0.3",
     "es6-promise": "^3.0.2",
     "hipchatter": "^0.2.0",
     "iconv": "^2.1.10",
     "isomorphic-fetch": "^2.1.1",
-    "menubar": "^2.1.2",
+    "menubar": "^4.1.2",
     "once": "^1.3.2",
     "playback": "^0.2.0",
-    "react": "^0.13.3"
+    "react": "^0.14.8",
+    "react-dom": "^0.14.7"
   },
   "devDependencies": {
-    "electron-packager": "^5.0.2",
-    "standard": "^5.1.0"
+    "electron-packager": "^7.2.0",
+    "standard": "^7.1.2"
   }
 }


### PR DESCRIPTION
- bump version to 1.1.1
- update npm start command to run `electron .`
- remove electron-template-menu dependency
- add toggle to turn automatic sending on/off (fix #11)

update packages (fix #10)
- update target electron version to 1.26
- update target electron packager version to 7.2.0
- update standard to 7.1.2
- update react version to 0.14.8
- update menubar to 4.1.2
- fix correct reference of menu item when packaging app through `npm run build`
